### PR TITLE
Implement the boot allocator

### DIFF
--- a/linker.ld
+++ b/linker.ld
@@ -37,12 +37,13 @@ SECTIONS
 	}
 
 	. = ALIGN(4K);
-	/* The mem_catalog chunk of memory is set aside for holding
-	the memory catalog, which will allow us to track the rest of
-	the system's memory dynamically. */
-	PROVIDE(mem_catalog_start = .);
+
+	/* The boot heap is a contiguous region of memory from which
+	we allocate memory until we set up our real, page-table aware
+	allocator. */
+	PROVIDE(boot_heap_start = .);
 	. += 8M;
-	PROVIDE(mem_catalog_end = .);
+	PROVIDE(boot_heap_end = .);
 
 	PROVIDE(kernel_end = .);
 }

--- a/src/kernel/boot_allocator.c
+++ b/src/kernel/boot_allocator.c
@@ -1,0 +1,19 @@
+#include <memory.h>
+
+#include "boot_allocator.h"
+#include "link_address.h"
+#include "panic.h"
+
+// boot_heap_start is page-aligned.
+static uintptr_t remaining_boot_heap = (uintptr_t) boot_heap_start;
+
+uintptr_t boot_allocate(size_t length) {
+  size_t page_aligned_length = aligned_up(length, kPageSize);
+  uintptr_t allocation = remaining_boot_heap;
+  remaining_boot_heap += page_aligned_length;
+  if (remaining_boot_heap > (uintptr_t) boot_heap_end) {
+    panic("Boot allocator out of memory.\n");
+  }
+  return allocation;
+}
+

--- a/src/kernel/boot_allocator.h
+++ b/src/kernel/boot_allocator.h
@@ -1,0 +1,9 @@
+#ifndef ASBESTOS_KERNEL_BOOT_ALLOCATOR_H_
+#define ASBESTOS_KERNEL_BOOT_ALLOCATOR_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+uintptr_t boot_allocate(size_t length);
+
+#endif  // ASBESTOS_KERNEL_BOOT_ALLOCATOR_H_

--- a/src/kernel/link_address.h
+++ b/src/kernel/link_address.h
@@ -4,9 +4,10 @@
 extern const char  kernel_start[];
 extern const char kernel_end[];
 
-// This pre-allocated chunk of memory holds data for tracking the rest
-// of the system's available memory.
-extern const char mem_catalog_start[];
-extern const char mem_catalog_end[];
+// This pre-allocated chunk of memory allows us to provide a bootstrap
+// allocator, even before we have a real, page-table aware allocator
+// setup.
+extern const char boot_heap_start[];
+extern const char boot_heap_end[];
 
 #endif  // ASBESTOS_KERNEL_LINK_ADDRESS_H_

--- a/src/kernel/memory_catalog.c
+++ b/src/kernel/memory_catalog.c
@@ -1,3 +1,4 @@
+#include <memory.h>
 #include "boot_allocator.h"
 #include "cprintf.h"
 #include "link_address.h"
@@ -50,8 +51,8 @@ void memory_catalog_free_page(struct MemoryCatalogBlock *block) {
 }
 
 void memory_catalog_initialize(struct MultibootInfo *multiboot_info) {
-  next_unused_block =
-      (struct MemoryCatalogBlock *) boot_allocate(8 * 1024 * 1024);
+  next_unused_block = (struct MemoryCatalogBlock *)
+    boot_allocate(sizeof(struct MemoryCatalogBlock) * kPagesPerMemorySpace);
 
   int memory_size_kibibytes = (multiboot_info->mem_lower +
 			       multiboot_info->mem_upper);

--- a/src/lib/memory.c
+++ b/src/lib/memory.c
@@ -1,0 +1,7 @@
+#include "memory.h"
+
+// Rounds an address up to a block boundary.
+// Requires that the block size is a power of two.
+uintptr_t aligned_up(uintptr_t address, size_t block_size) {
+  return (address + block_size - 1) & ~(block_size - 1);
+}

--- a/src/lib/memory.h
+++ b/src/lib/memory.h
@@ -1,0 +1,12 @@
+#ifndef ASBESTOS_LIB_MEMORY_H_
+#define ASBESTOS_LIB_MEMORY_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+static const size_t kPageSize = 1 << 12;
+static const int kPagesPerMemorySpace = 1 << 20;
+
+uintptr_t aligned_up(uintptr_t address, size_t block_size);
+
+#endif  // ASBESTOS_LIB_MEMORY_H_


### PR DESCRIPTION
The boot allocator allocates contiguous chunks of memory from the "boot heap."  It allows us to allocate memory before our intelligent, paging-aware allocator is setup.  (So, if we need to allocate memory in order to setup the intelligent allocator, we must use this boot allocator.)

This pull request replaces the specific `mem_catalog_start` and `mem_catalog_end` labels with the general `boot_heap_start` and `boot_heap_end` labels.