### PR TITLE
Implement segmentation scheme.

### DIFF
--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -6,6 +6,7 @@
 #include "multiboot.h"
 #include "panic.h"
 #include "keyboard.h"
+#include "segmentation.h"
 #include "serial.h"
 #include "vga.h"
 
@@ -35,6 +36,9 @@ void kernel_validate_multiboot_handoff(uint32_t handoff_eax,
 void kernel_main(struct PushedRegisters registers) {
   kernel_initialize_terminal();
   cprintf("Starting up Asbestos.\n");
+
+  cprintf("Updating segmentation scheme.\n")
+  segmentation_initialize();
 
   struct MultibootInfo *multiboot_info = (struct MultibootInfo *) registers.ebx;
   kernel_validate_multiboot_handoff(registers.eax, multiboot_info);

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -37,7 +37,7 @@ void kernel_main(struct PushedRegisters registers) {
   kernel_initialize_terminal();
   cprintf("Starting up Asbestos.\n");
 
-  cprintf("Updating segmentation scheme.\n")
+  cprintf("Updating segmentation scheme.\n");
   segmentation_initialize();
 
   struct MultibootInfo *multiboot_info = (struct MultibootInfo *) registers.ebx;

--- a/src/kernel/segmentation.c
+++ b/src/kernel/segmentation.c
@@ -20,6 +20,7 @@ struct SegmentDescriptor spanning_gdt_entry(
       .local = true,
       .present = true,
       .limit_19_16 = 0xf,
+      .default_size = 1, // Default to 32-bit operations.
       .granularity = true  // Multiply limit by 4KB.
   };
   return result;

--- a/src/kernel/segmentation.c
+++ b/src/kernel/segmentation.c
@@ -16,6 +16,8 @@ struct SegmentDescriptor spanning_gdt_entry(
       .limit_15_0 = 0xffff,
       .writable = writable,
       .executable = executable,
+      // TODO(jasonpr): Rename.
+      .local = true,
       .present = true,
       .limit_19_16 = 0xf,
       .granularity = true  // Multiply limit by 4KB.

--- a/src/kernel/segmentation.c
+++ b/src/kernel/segmentation.c
@@ -16,8 +16,7 @@ struct SegmentDescriptor spanning_gdt_entry(
       .limit_15_0 = 0xffff,
       .writable = writable,
       .executable = executable,
-      // TODO(jasonpr): Rename.
-      .local = true,
+      .non_system = true,
       .present = true,
       .limit_19_16 = 0xf,
       .default_size = 1, // Default to 32-bit operations.

--- a/src/kernel/segmentation.c
+++ b/src/kernel/segmentation.c
@@ -1,4 +1,5 @@
 #include <stdbool.h>
+#include <segments.h>
 #include <x86.h>
 #include "segmentation.h"
 

--- a/src/kernel/segmentation.c
+++ b/src/kernel/segmentation.c
@@ -28,7 +28,11 @@ void initialize_gdt() {
   gdt[GDT_NULL_SEGMENT_OFFSET] = (struct SegmentDescriptor) {0};
 
   // Add a code segment.
-  gdt[GDT_CODE_SEGMENT_OFFSET] = spanning_gdt_entry(false, true);
+  // I can't find documentation that the code segment must be
+  // writeable.  But, it's the only way I can avoid a GP fault, and
+  // GRUB makes a writeable code segment, too.  So, it's probably
+  // okay!
+  gdt[GDT_CODE_SEGMENT_OFFSET] = spanning_gdt_entry(true, true);
 
   // Add a data segment.
   gdt[GDT_DATA_SEGMENT_OFFSET] = spanning_gdt_entry(true, false);

--- a/src/kernel/segmentation.c
+++ b/src/kernel/segmentation.c
@@ -29,7 +29,11 @@ void initialize_gdt() {
   // Add a data segment.
   gdt[GDT_DATA_SEGMENT_OFFSET] = spanning_gdt_entry(true, false);
 
-  // TODO(jasonpr): Actually load the GDT!
+  struct PseudoDescriptor gdt_descriptor = {
+    .limit = sizeof(struct SegmentDescriptor) * GDT_SIZE - 1,
+    .base = (uintptr_t) &gdt
+  };
+  load_gdt(&gdt_descriptor);
 }
 
 void initialize_selectors() {

--- a/src/kernel/segmentation.c
+++ b/src/kernel/segmentation.c
@@ -1,0 +1,64 @@
+#include <stdbool.h>
+#include <x86.h>
+#include "segmentation.h"
+
+static struct SegmentDescriptor gdt[GDT_SIZE];
+
+// Make a segment that spans the whole 32-bit address space.
+struct SegmentDescriptor spanning_gdt_entry(
+    bool writable, bool executable) {
+  struct SegmentDescriptor result = {
+      .limit_15_0 = 0xffff,
+      .writable = writable,
+      .executable = executable,
+      .present = true,
+      .limit_19_16 = 0xf,
+      .granularity = true  // Multiply limit by 4KB.
+  };
+  return result;
+}
+
+void initialize_gdt() {
+  // Start with the null segment.
+  gdt[GDT_NULL_SEGMENT_OFFSET] = (struct SegmentDescriptor) {0};
+
+  // Add a code segment.
+  gdt[GDT_CODE_SEGMENT_OFFSET] = spanning_gdt_entry(false, true);
+
+  // Add a data segment.
+  gdt[GDT_DATA_SEGMENT_OFFSET] = spanning_gdt_entry(true, false);
+
+  // TODO(jasonpr): Actually load the GDT!
+}
+
+void initialize_selectors() {
+  struct SegmentSelector null_selector = {
+    .index = GDT_NULL_SEGMENT_OFFSET
+  };
+
+  struct SegmentSelector code_selector = {
+    .index = GDT_CODE_SEGMENT_OFFSET
+  };
+
+  struct SegmentSelector data_selector = {
+    .index = GDT_DATA_SEGMENT_OFFSET
+  };
+
+  load_cs(code_selector);
+
+  // Load DS for normal data access, SS for stack access, and ES for
+  // string-related data access.
+  load_ds(data_selector);
+  load_ss(data_selector);
+  load_es(data_selector);
+
+  // We don't use the general-purpose segments.  Make sure we segfault
+  // if we accidentally use them.
+  load_fs(null_selector);
+  load_gs(null_selector);
+}
+
+void segmentation_initialize() {
+  initialize_gdt();
+  initialize_selectors();
+}

--- a/src/kernel/segmentation.c
+++ b/src/kernel/segmentation.c
@@ -4,6 +4,10 @@
 #include "segmentation.h"
 
 static struct SegmentDescriptor gdt[GDT_SIZE];
+static struct PseudoDescriptor gdt_descriptor = {
+  .limit = sizeof(struct SegmentDescriptor) * GDT_SIZE - 1,
+  .base = (uintptr_t) &gdt
+};
 
 // Make a segment that spans the whole 32-bit address space.
 struct SegmentDescriptor spanning_gdt_entry(
@@ -29,11 +33,8 @@ void initialize_gdt() {
   // Add a data segment.
   gdt[GDT_DATA_SEGMENT_OFFSET] = spanning_gdt_entry(true, false);
 
-  struct PseudoDescriptor gdt_descriptor = {
-    .limit = sizeof(struct SegmentDescriptor) * GDT_SIZE - 1,
-    .base = (uintptr_t) &gdt
-  };
-  load_gdt(&gdt_descriptor);
+  uintptr_t lgdt_target = pseudo_descriptor_gdt_address(&gdt_descriptor);
+  load_gdt(lgdt_target);
 }
 
 void initialize_selectors() {

--- a/src/kernel/segmentation.c
+++ b/src/kernel/segmentation.c
@@ -19,8 +19,8 @@ struct SegmentDescriptor spanning_gdt_entry(
       .non_system = true,
       .present = true,
       .limit_19_16 = 0xf,
-      .default_size = 1, // Default to 32-bit operations.
-      .granularity = true  // Multiply limit by 4KB.
+      .default_size_32 = true,
+      .granularity_4k = true
   };
   return result;
 }

--- a/src/kernel/segmentation.h
+++ b/src/kernel/segmentation.h
@@ -40,10 +40,10 @@ struct SegmentDescriptor {
   uint8_t base_31_24;
 } __attribute__((packed));
 
-#define GDT_SIZE 3
 #define GDT_NULL_SEGMENT_OFFSET 0
 #define GDT_CODE_SEGMENT_OFFSET 1
 #define GDT_DATA_SEGMENT_OFFSET 2
+#define GDT_SIZE 3
 
 void segmentation_initialize();
 

--- a/src/kernel/segmentation.h
+++ b/src/kernel/segmentation.h
@@ -1,0 +1,42 @@
+#ifndef ASBESTOS_KERNEL_SEGMENT_H_
+#define ASBESTOS_KERNEL_SEGMENT_H_
+
+#include <stdint.h>
+
+// Useful resources:
+// http://www.intel.com/design/pentium/manuals/24143004.pdf
+// https://css.csail.mit.edu/6.858/2010/readings/i386.pdf
+
+struct SegmentDescriptor {
+  // The low 15 bits of the segment limit.  Multiply by by 4KB if
+  // granularity bit is set, or by 1 byte if granularity bit is
+  // cleared.
+  uint16_t limit_15_0;
+  // The low 15 bits of the base address.
+  uint16_t base_15_0;
+  uint8_t base_23_16;
+  // Set by the whenever it uses this segment.
+  unsigned int accessed : 1;
+  unsigned int writable : 1;
+  // Pertains to variable-sized segments.  Clear it and forget it.
+  unsigned int expand_down : 1;
+  // If set, it's a code segment.  If cleared, it's a data segment.
+  unsigned int executable : 1;
+  // If set, it's an LDT entry.  If cleared, it's a GDT entry.
+  unsigned int local : 1;
+  // DPL.  System is 0, user is 3.
+  unsigned int privilege_level : 2;
+  unsigned int present : 1;
+  unsigned int limit_19_16 : 4;
+  // Available for our own use.
+  unsigned int unused : 1;
+  unsigned int reserved : 1;
+  // If set, operations in this segment default to 32-bit operations.
+  // If cleared, they default to 16-bit operations.
+  unsigned int default_size : 1;
+  // See the limit_* fields.
+  unsigned int granularity : 1;
+  uint8_t base_31_24;
+} __attribute__((packed));
+
+#endif  // ASBESTOS_KERNEL_SEGMENT_H_

--- a/src/kernel/segmentation.h
+++ b/src/kernel/segmentation.h
@@ -24,7 +24,7 @@ struct SegmentDescriptor {
   // If set, it's a code segment.  If cleared, it's a data segment.
   unsigned int executable : 1;
   // If set, it's an LDT entry.  If cleared, it's a GDT entry.
-  unsigned int local : 1;
+  unsigned int non_system : 1;
   // DPL.  System is 0, user is 3.
   unsigned int privilege_level : 2;
   unsigned int present : 1;

--- a/src/kernel/segmentation.h
+++ b/src/kernel/segmentation.h
@@ -34,9 +34,9 @@ struct SegmentDescriptor {
   unsigned int reserved : 1;
   // If set, operations in this segment default to 32-bit operations.
   // If cleared, they default to 16-bit operations.
-  unsigned int default_size : 1;
+  unsigned int default_size_32 : 1;
   // See the limit_* fields.
-  unsigned int granularity : 1;
+  unsigned int granularity_4k : 1;
   uint8_t base_31_24;
 } __attribute__((packed));
 

--- a/src/kernel/segmentation.h
+++ b/src/kernel/segmentation.h
@@ -2,6 +2,7 @@
 #define ASBESTOS_KERNEL_SEGMENT_H_
 
 #include <stdint.h>
+#include <x86.h>
 
 // Useful resources:
 // http://www.intel.com/design/pentium/manuals/24143004.pdf
@@ -39,15 +40,11 @@ struct SegmentDescriptor {
   uint8_t base_31_24;
 } __attribute__((packed));
 
-struct SegmentSelector {
-  // What privileges the CPU must require to use this segment.
-  // If the referenced descriptor has a stricter privilege level,
-  // then that constraint will be enforced instead.
-  unsigned int requested_privilege_level : 2;
-  // Which table contains the segment. 0 = GDT, 1 = LDT.
-  unsigned int local : 1;
-  // The index into the descriptor table.
-  unsigned int index : 13;
-} __attribute__((packed));
+#define GDT_SIZE 3
+#define GDT_NULL_SEGMENT_OFFSET 0
+#define GDT_CODE_SEGMENT_OFFSET 1
+#define GDT_DATA_SEGMENT_OFFSET 2
+
+void segmentation_initialize();
 
 #endif  // ASBESTOS_KERNEL_SEGMENT_H_

--- a/src/kernel/segmentation.h
+++ b/src/kernel/segmentation.h
@@ -39,4 +39,15 @@ struct SegmentDescriptor {
   uint8_t base_31_24;
 } __attribute__((packed));
 
+struct SegmentSelector {
+  // What privileges the CPU must require to use this segment.
+  // If the referenced descriptor has a stricter privilege level,
+  // then that constraint will be enforced instead.
+  unsigned int requested_privilege_level : 2;
+  // Which table contains the segment. 0 = GDT, 1 = LDT.
+  unsigned int local : 1;
+  // The index into the descriptor table.
+  unsigned int index : 13;
+} __attribute__((packed));
+
 #endif  // ASBESTOS_KERNEL_SEGMENT_H_

--- a/src/lib/segments.c
+++ b/src/lib/segments.c
@@ -1,0 +1,7 @@
+#include <segments.h>
+#include <stdint.h>
+
+uintptr_t pseudo_descriptor_gdt_address(struct PseudoDescriptor *pd) {
+  // The first two bytes are padding.
+  return ((uintptr_t) pd) + 2;
+}

--- a/src/lib/segments.h
+++ b/src/lib/segments.h
@@ -18,4 +18,6 @@ struct PseudoDescriptor {
   uint32_t base;
 } __attribute__((aligned(4), packed));
 
+uintptr_t pseudo_descriptor_gdt_address(struct PseudoDescriptor *pd);
+
 #endif  // ASBESTOS_LIB_SEGMENTS_H_

--- a/src/lib/segments.h
+++ b/src/lib/segments.h
@@ -1,6 +1,8 @@
 #ifndef ASBESTOS_LIB_SEGMENTS_H_
 #define ASBESTOS_LIB_SEGMENTS_H_
 
+#include <stdint.h>
+
 struct SegmentSelector {
   // What privileges the CPU must require to use this segment.
   // If the referenced descriptor has a stricter privilege level,

--- a/src/lib/segments.h
+++ b/src/lib/segments.h
@@ -17,7 +17,7 @@ struct SegmentSelector {
 struct PseudoDescriptor {
   uint16_t alignment_padding;
   uint16_t limit;
-  uint32_t base;
+  uintptr_t base;
 } __attribute__((aligned(4), packed));
 
 uintptr_t pseudo_descriptor_gdt_address(struct PseudoDescriptor *pd);

--- a/src/lib/segments.h
+++ b/src/lib/segments.h
@@ -1,0 +1,15 @@
+#ifndef ASBESTOS_LIB_SEGMENTS_H_
+#define ASBESTOS_LIB_SEGMENTS_H_
+
+struct SegmentSelector {
+  // What privileges the CPU must require to use this segment.
+  // If the referenced descriptor has a stricter privilege level,
+  // then that constraint will be enforced instead.
+  unsigned int requested_privilege_level : 2;
+  // Which table contains the segment. 0 = GDT, 1 = LDT.
+  unsigned int local : 1;
+  // The index into the descriptor table.
+  unsigned int index : 13;
+} __attribute__((packed));
+
+#endif  // ASBESTOS_LIB_SEGMENTS_H_

--- a/src/lib/segments.h
+++ b/src/lib/segments.h
@@ -12,4 +12,10 @@ struct SegmentSelector {
   unsigned int index : 13;
 } __attribute__((packed));
 
+struct PseudoDescriptor {
+  uint16_t alignment_padding;
+  uint16_t limit;
+  uint32_t base;
+} __attribute__((aligned(4), packed));
+
 #endif  // ASBESTOS_LIB_SEGMENTS_H_

--- a/src/lib/x86.h
+++ b/src/lib/x86.h
@@ -1,21 +1,10 @@
 #ifndef X86_H_
 #define X86_H_
 
+#include <segments.h>
 #include <stdint.h>
 
 // This file is heavily influenced by JOS's inc/x86.h.
-
-// TODO(jasonpr): Determine whether this belongs in another file.
-struct SegmentSelector {
-  // What privileges the CPU must require to use this segment.
-  // If the referenced descriptor has a stricter privilege level,
-  // then that constraint will be enforced instead.
-  unsigned int requested_privilege_level : 2;
-  // Which table contains the segment. 0 = GDT, 1 = LDT.
-  unsigned int local : 1;
-  // The index into the descriptor table.
-  unsigned int index : 13;
-} __attribute__((packed));
 
 // Usually, we discourage inlining via command line flags. But, we
 // want our instruction wrapper functions to be inlined.  So, we mark

--- a/src/lib/x86.h
+++ b/src/lib/x86.h
@@ -19,6 +19,7 @@ static __inline void load_es(struct SegmentSelector selector) __attribute__((alw
 static __inline void load_fs(struct SegmentSelector selector) __attribute__((always_inline));
 static __inline void load_gs(struct SegmentSelector selector) __attribute__((always_inline));
 static __inline void load_ss(struct SegmentSelector selector) __attribute__((always_inline));
+static __inline void load_gdt(struct PseudoDescriptor *pd) __attribute__((always_inline));
 
 
 // Get the current base pointer.
@@ -92,6 +93,12 @@ static void load_ss(struct SegmentSelector selector) {
   __asm __volatile("mov %0, %%ss" :
 		   /* No output. */ :
 		   "r" (selector));
+}
+
+static void load_gdt(struct PseudoDescriptor *pd) {
+  __asm __volatile("lgdt %0" :
+		   /* No output. */ :
+		   "r" (pseudo_descriptor_gdt_address(pd)));
 }
 
 struct PushedRegisters {

--- a/src/lib/x86.h
+++ b/src/lib/x86.h
@@ -19,7 +19,7 @@ static __inline void load_es(struct SegmentSelector selector) __attribute__((alw
 static __inline void load_fs(struct SegmentSelector selector) __attribute__((always_inline));
 static __inline void load_gs(struct SegmentSelector selector) __attribute__((always_inline));
 static __inline void load_ss(struct SegmentSelector selector) __attribute__((always_inline));
-static __inline void load_gdt(struct PseudoDescriptor *pd) __attribute__((always_inline));
+static __inline void load_gdt(uintptr_t start) __attribute__((always_inline));
 
 
 // Get the current base pointer.
@@ -95,10 +95,10 @@ static void load_ss(struct SegmentSelector selector) {
 		   "r" (selector));
 }
 
-static void load_gdt(struct PseudoDescriptor *pd) {
-  __asm __volatile("lgdt %0" :
+static void load_gdt(uintptr_t start) {
+  __asm __volatile("lgdt (%0)" :
 		   /* No output. */ :
-		   "r" (pseudo_descriptor_gdt_address(pd)));
+		   "r" (start));
 }
 
 struct PushedRegisters {

--- a/src/lib/x86.h
+++ b/src/lib/x86.h
@@ -5,6 +5,18 @@
 
 // This file is heavily influenced by JOS's inc/x86.h.
 
+// TODO(jasonpr): Determine whether this belongs in another file.
+struct SegmentSelector {
+  // What privileges the CPU must require to use this segment.
+  // If the referenced descriptor has a stricter privilege level,
+  // then that constraint will be enforced instead.
+  unsigned int requested_privilege_level : 2;
+  // Which table contains the segment. 0 = GDT, 1 = LDT.
+  unsigned int local : 1;
+  // The index into the descriptor table.
+  unsigned int index : 13;
+} __attribute__((packed));
+
 // Usually, we discourage inlining via command line flags. But, we
 // want our instruction wrapper functions to be inlined.  So, we mark
 // all of them with always_inline.
@@ -12,6 +24,13 @@
 static __inline uintptr_t get_ebp() __attribute__((always_inline));
 static __inline uint8_t inb(uint16_t io_port) __attribute__((always_inline));
 static __inline void outb(uint16_t io_port, uint8_t data) __attribute__((always_inline));
+static __inline void load_cs(struct SegmentSelector selector) __attribute__((always_inline));
+static __inline void load_ds(struct SegmentSelector selector) __attribute__((always_inline));
+static __inline void load_es(struct SegmentSelector selector) __attribute__((always_inline));
+static __inline void load_fs(struct SegmentSelector selector) __attribute__((always_inline));
+static __inline void load_gs(struct SegmentSelector selector) __attribute__((always_inline));
+static __inline void load_ss(struct SegmentSelector selector) __attribute__((always_inline));
+
 
 // Get the current base pointer.
 
@@ -38,6 +57,52 @@ static void outb(uint16_t io_port, uint8_t data) {
   __asm __volatile("outb %0, %1" :
 		   /* No output. */ : 
 		   "a" (data), "d" (io_port));
+}
+
+static void load_cs(struct SegmentSelector selector) {
+  // Change the CS with a long return.
+  // Thanks to Owen at http://f.osdev.org/viewtopic.php?f=1&t=22641
+
+  // Pad the 16-bit selector to 32 bits so it can be pushed onto the
+  // stack.
+  uint32_t padded_selector = *((uint16_t *) &selector);
+
+  __asm __volatile("push %0\n\t"
+		   "push $flush_cs\n\t"
+		   "retf\n\t"
+		   "flush_cs:" :
+		   /* No output. */ :
+		   "r" (padded_selector));
+}
+
+static void load_ds(struct SegmentSelector selector) {
+  __asm __volatile("mov %0, %%ds" :
+		   /* No output. */ :
+		   "r" (selector));
+}
+
+static void load_es(struct SegmentSelector selector) {
+  __asm __volatile("mov %0, %%es" :
+		   /* No output. */ :
+		   "r" (selector));
+}
+
+static void load_fs(struct SegmentSelector selector) {
+  __asm __volatile("mov %0, %%fs" :
+		   /* No output. */ :
+		   "r" (selector));
+}
+
+static void load_gs(struct SegmentSelector selector) {
+  __asm __volatile("mov %0, %%gs" :
+		   /* No output. */ :
+		   "r" (selector));
+}
+
+static void load_ss(struct SegmentSelector selector) {
+  __asm __volatile("mov %0, %%ss" :
+		   /* No output. */ :
+		   "r" (selector));
 }
 
 struct PushedRegisters {


### PR DESCRIPTION
That is, create a GDT, and update the segment selectors to use it.

This is a good idea for two reasons:
  * We never use the FS or GS segments, so we want to point them to a null descriptor.
  * The Multiboot spec isn't 100% clear, but it seems to encourage setting up a GDT rather than relying on the bootloaders GDT.  See http://www.gnu.org/software/grub/manual/multiboot/multiboot.html#Machine-state.

We now have segment for CS and one for DS/ES/SS, with FS and GS pointing at the null segment.