### PR TITLE
Implement primitive interrupt handling

### DIFF
--- a/src/kernel/interrupt_entry.S
+++ b/src/kernel/interrupt_entry.S
@@ -1,0 +1,90 @@
+#include <src/kernel/interrupts.h>
+
+trap_handler_0:
+	push $0
+	call handle_interrupt
+
+trap_handler_1:
+	push $1
+	call handle_interrupt
+
+trap_handler_2:
+	push $2
+	call handle_interrupt
+
+trap_handler_3:
+	push $3
+	call handle_interrupt
+
+trap_handler_4:
+	push $4
+	call handle_interrupt
+
+trap_handler_5:
+	push $5
+	call handle_interrupt
+
+trap_handler_6:
+	push $6
+	call handle_interrupt
+
+trap_handler_7:
+	push $7
+	call handle_interrupt
+
+trap_handler_8:
+	push $8
+	call handle_interrupt
+
+trap_handler_9:
+	push $9
+	call handle_interrupt
+
+trap_handler_10:
+	push $10
+	call handle_interrupt
+
+trap_handler_11:
+	push $11
+	call handle_interrupt
+
+trap_handler_12:
+	push $12
+	call handle_interrupt
+
+trap_handler_13:
+	push $13
+	call handle_interrupt
+
+trap_handler_14:
+	push $14
+	call handle_interrupt
+
+trap_handler_15:
+	push $15
+	call handle_interrupt
+
+trap_handler_16:
+	push $16
+	call handle_interrupt
+
+.align 4
+.global trap_functions
+trap_functions:
+	.long trap_handler_0
+	.long trap_handler_1
+	.long trap_handler_2
+	.long trap_handler_3
+	.long trap_handler_4
+	.long trap_handler_5
+	.long trap_handler_6
+	.long trap_handler_7
+	.long trap_handler_8
+	.long trap_handler_9
+	.long trap_handler_10
+	.long trap_handler_11
+	.long trap_handler_12
+	.long trap_handler_13
+	.long trap_handler_14
+	.long trap_handler_15
+	.long trap_handler_16

--- a/src/kernel/interrupt_entry.S
+++ b/src/kernel/interrupt_entry.S
@@ -2,70 +2,74 @@
 
 trap_handler_0:
 	push $0
-	call handle_interrupt
+	jmp call_handler
 
 trap_handler_1:
 	push $1
-	call handle_interrupt
+	jmp call_handler
 
 trap_handler_2:
 	push $2
-	call handle_interrupt
+	jmp call_handler
 
 trap_handler_3:
 	push $3
-	call handle_interrupt
+	jmp call_handler
 
 trap_handler_4:
 	push $4
-	call handle_interrupt
+	jmp call_handler
 
 trap_handler_5:
 	push $5
-	call handle_interrupt
+	jmp call_handler
 
 trap_handler_6:
 	push $6
-	call handle_interrupt
+	jmp call_handler
 
 trap_handler_7:
 	push $7
-	call handle_interrupt
+	jmp call_handler
 
 trap_handler_8:
 	push $8
-	call handle_interrupt
+	jmp call_handler
 
 trap_handler_9:
 	push $9
-	call handle_interrupt
+	jmp call_handler
 
 trap_handler_10:
 	push $10
-	call handle_interrupt
+	jmp call_handler
 
 trap_handler_11:
 	push $11
-	call handle_interrupt
+	jmp call_handler
 
 trap_handler_12:
 	push $12
-	call handle_interrupt
+	jmp call_handler
 
 trap_handler_13:
 	push $13
-	call handle_interrupt
+	jmp call_handler
 
 trap_handler_14:
 	push $14
-	call handle_interrupt
+	jmp call_handler
 
 trap_handler_15:
 	push $15
-	call handle_interrupt
+	jmp call_handler
 
 trap_handler_16:
 	push $16
+	jmp call_handler
+
+// Call the interrupt handler. Pass the trap frame as an argument.
+call_handler:
 	call handle_interrupt
 
 .align 4

--- a/src/kernel/interrupt_entry.S
+++ b/src/kernel/interrupt_entry.S
@@ -1,10 +1,14 @@
 #include <src/kernel/interrupts.h>
 
 trap_handler_0:
+	// Push dummy error code.
+	push $0
 	push $0
 	jmp call_handler
 
 trap_handler_1:
+	// Push dummy error code.
+	push $0
 	push $1
 	jmp call_handler
 
@@ -13,22 +17,32 @@ trap_handler_2:
 	jmp call_handler
 
 trap_handler_3:
+	// Push dummy error code.
+	push $0
 	push $3
 	jmp call_handler
 
 trap_handler_4:
+	// Push dummy error code.
+	push $0
 	push $4
 	jmp call_handler
 
 trap_handler_5:
+	// Push dummy error code.
+	push $0
 	push $5
 	jmp call_handler
 
 trap_handler_6:
+	// Push dummy error code.
+	push $0
 	push $6
 	jmp call_handler
 
 trap_handler_7:
+	// Push dummy error code.
+	push $0
 	push $7
 	jmp call_handler
 
@@ -37,6 +51,8 @@ trap_handler_8:
 	jmp call_handler
 
 trap_handler_9:
+	// Push dummy error code.
+	push $0
 	push $9
 	jmp call_handler
 
@@ -65,11 +81,14 @@ trap_handler_15:
 	jmp call_handler
 
 trap_handler_16:
+	// Push dummy error code.
+	push $0
 	push $16
 	jmp call_handler
 
 // Call the interrupt handler. Pass the trap frame as an argument.
 call_handler:
+	pushal
 	call handle_interrupt
 
 .align 4

--- a/src/kernel/interrupt_entry.S
+++ b/src/kernel/interrupt_entry.S
@@ -354,6 +354,10 @@ trap_handler_60:
 call_handler:
 	pushal
 	call handle_interrupt
+	popal
+	// Remove interrupt number and error code.
+	add $8, %esp
+	iret
 
 .align 4
 .global trap_functions

--- a/src/kernel/interrupt_entry.S
+++ b/src/kernel/interrupt_entry.S
@@ -86,6 +86,270 @@ trap_handler_16:
 	push $16
 	jmp call_handler
 
+trap_handler_17:
+	// Push dummy error code.
+	push $0
+	push $17
+	jmp call_handler
+
+trap_handler_18:
+	// Push dummy error code.
+	push $0
+	push $18
+	jmp call_handler
+
+trap_handler_19:
+	// Push dummy error code.
+	push $0
+	push $19
+	jmp call_handler
+
+trap_handler_20:
+	// Push dummy error code.
+	push $0
+	push $20
+	jmp call_handler
+
+trap_handler_21:
+	// Push dummy error code.
+	push $0
+	push $21
+	jmp call_handler
+
+trap_handler_22:
+	// Push dummy error code.
+	push $0
+	push $22
+	jmp call_handler
+
+trap_handler_23:
+	// Push dummy error code.
+	push $0
+	push $23
+	jmp call_handler
+
+trap_handler_24:
+	// Push dummy error code.
+	push $0
+	push $24
+	jmp call_handler
+
+trap_handler_25:
+	// Push dummy error code.
+	push $0
+	push $25
+	jmp call_handler
+
+trap_handler_26:
+	// Push dummy error code.
+	push $0
+	push $26
+	jmp call_handler
+
+trap_handler_27:
+	// Push dummy error code.
+	push $0
+	push $27
+	jmp call_handler
+
+trap_handler_28:
+	// Push dummy error code.
+	push $0
+	push $28
+	jmp call_handler
+
+trap_handler_29:
+	// Push dummy error code.
+	push $0
+	push $29
+	jmp call_handler
+
+trap_handler_30:
+	// Push dummy error code.
+	push $0
+	push $30
+	jmp call_handler
+
+trap_handler_31:
+	// Push dummy error code.
+	push $0
+	push $31
+	jmp call_handler
+
+trap_handler_32:
+	// Push dummy error code.
+	push $0
+	push $32
+	jmp call_handler
+
+trap_handler_33:
+	// Push dummy error code.
+	push $0
+	push $33
+	jmp call_handler
+
+trap_handler_34:
+	// Push dummy error code.
+	push $0
+	push $34
+	jmp call_handler
+
+trap_handler_35:
+	// Push dummy error code.
+	push $0
+	push $35
+	jmp call_handler
+
+trap_handler_36:
+	// Push dummy error code.
+	push $0
+	push $36
+	jmp call_handler
+
+trap_handler_37:
+	// Push dummy error code.
+	push $0
+	push $37
+	jmp call_handler
+
+trap_handler_38:
+	// Push dummy error code.
+	push $0
+	push $38
+	jmp call_handler
+
+trap_handler_39:
+	// Push dummy error code.
+	push $0
+	push $39
+	jmp call_handler
+
+trap_handler_40:
+	// Push dummy error code.
+	push $0
+	push $40
+	jmp call_handler
+
+trap_handler_41:
+	// Push dummy error code.
+	push $0
+	push $41
+	jmp call_handler
+
+trap_handler_42:
+	// Push dummy error code.
+	push $0
+	push $42
+	jmp call_handler
+
+trap_handler_43:
+	// Push dummy error code.
+	push $0
+	push $43
+	jmp call_handler
+
+trap_handler_44:
+	// Push dummy error code.
+	push $0
+	push $44
+	jmp call_handler
+
+trap_handler_45:
+	// Push dummy error code.
+	push $0
+	push $45
+	jmp call_handler
+
+trap_handler_46:
+	// Push dummy error code.
+	push $0
+	push $46
+	jmp call_handler
+
+trap_handler_47:
+	// Push dummy error code.
+	push $0
+	push $47
+	jmp call_handler
+
+trap_handler_48:
+	// Push dummy error code.
+	push $0
+	push $48
+	jmp call_handler
+
+trap_handler_49:
+	// Push dummy error code.
+	push $0
+	push $49
+	jmp call_handler
+
+trap_handler_50:
+	// Push dummy error code.
+	push $0
+	push $50
+	jmp call_handler
+
+trap_handler_51:
+	// Push dummy error code.
+	push $0
+	push $51
+	jmp call_handler
+
+trap_handler_52:
+	// Push dummy error code.
+	push $0
+	push $52
+	jmp call_handler
+
+trap_handler_53:
+	// Push dummy error code.
+	push $0
+	push $53
+	jmp call_handler
+
+trap_handler_54:
+	// Push dummy error code.
+	push $0
+	push $54
+	jmp call_handler
+
+trap_handler_55:
+	// Push dummy error code.
+	push $0
+	push $55
+	jmp call_handler
+
+trap_handler_56:
+	// Push dummy error code.
+	push $0
+	push $56
+	jmp call_handler
+
+trap_handler_57:
+	// Push dummy error code.
+	push $0
+	push $57
+	jmp call_handler
+
+trap_handler_58:
+	// Push dummy error code.
+	push $0
+	push $58
+	jmp call_handler
+
+trap_handler_59:
+	// Push dummy error code.
+	push $0
+	push $59
+	jmp call_handler
+
+trap_handler_60:
+	// Push dummy error code.
+	push $0
+	push $60
+	jmp call_handler
+
 // Call the interrupt handler. Pass the trap frame as an argument.
 call_handler:
 	pushal
@@ -111,3 +375,47 @@ trap_functions:
 	.long trap_handler_14
 	.long trap_handler_15
 	.long trap_handler_16
+	.long trap_handler_17
+	.long trap_handler_18
+	.long trap_handler_19
+	.long trap_handler_20
+	.long trap_handler_21
+	.long trap_handler_22
+	.long trap_handler_23
+	.long trap_handler_24
+	.long trap_handler_25
+	.long trap_handler_26
+	.long trap_handler_27
+	.long trap_handler_28
+	.long trap_handler_29
+	.long trap_handler_30
+	.long trap_handler_31
+	.long trap_handler_32
+	.long trap_handler_33
+	.long trap_handler_34
+	.long trap_handler_35
+	.long trap_handler_36
+	.long trap_handler_37
+	.long trap_handler_38
+	.long trap_handler_39
+	.long trap_handler_40
+	.long trap_handler_41
+	.long trap_handler_42
+	.long trap_handler_43
+	.long trap_handler_44
+	.long trap_handler_45
+	.long trap_handler_46
+	.long trap_handler_47
+	.long trap_handler_48
+	.long trap_handler_49
+	.long trap_handler_50
+	.long trap_handler_51
+	.long trap_handler_52
+	.long trap_handler_53
+	.long trap_handler_54
+	.long trap_handler_55
+	.long trap_handler_56
+	.long trap_handler_57
+	.long trap_handler_58
+	.long trap_handler_59
+	.long trap_handler_60

--- a/src/kernel/interrupts.c
+++ b/src/kernel/interrupts.c
@@ -1,0 +1,41 @@
+#include <stdbool.h>
+#include <x86.h>
+
+#include "interrupts.h"
+#include "panic.h"
+#include "segmentation.h"
+
+static struct InterruptDescriptor idt[IDT_SIZE];
+
+static struct PseudoDescriptor idt_descriptor = {
+  .limit = sizeof(struct InterruptDescriptor) * IDT_SIZE - 1,
+  .base = (uintptr_t) &idt
+};
+
+struct InterruptDescriptor idt_entry(uintptr_t handler_pointer) {
+  struct InterruptDescriptor result = {
+    .offset_15_0 = handler_pointer & 0xFFFF,
+    .selector = GDT_CODE_SELECTOR,
+    .flags = 0b01111,  // The default value.
+    .present = true,
+    .offset_31_16 = (handler_pointer) >> 16
+  };
+  return result;
+}
+
+void handle_interrupt(int interrupt) {
+  disable_interrupts();
+  panic("Got interrupt %d.\n", interrupt);
+}
+
+void setup_idt() {
+  for (int entry = 0; entry < IDT_SIZE; entry++) {
+    idt[entry] = idt_entry((uintptr_t) trap_functions[entry]);
+  }
+  load_idt(&idt_descriptor);
+}
+
+void interrupts_initialize() {
+  setup_idt();
+  enable_interrupts();
+}

--- a/src/kernel/interrupts.c
+++ b/src/kernel/interrupts.c
@@ -83,6 +83,12 @@ void handle_interrupt(struct TrapFrame trap_frame) {
   case INTERRUPT_COPROCESSOR_ERROR:
     panic("Coprocessor error.\n");
     break;
+  case INTERRUPT_PASS_THROUGH:
+    cprintf("Handling pass-through interrupt.\n");
+    break;
+  case INTERRUPT_SYSCALL:
+    panic("Syscall.\n");
+    break;
   default:
     panic("Unidentified interrupt: %d.\n", trap_frame.interrupt_number);
     break;

--- a/src/kernel/interrupts.c
+++ b/src/kernel/interrupts.c
@@ -81,6 +81,20 @@ void handle_interrupt(int interrupt) {
   }
 }
 
+// TODO(jasonpr): Define these in a much better place!
+#define PIC_MASTER 0x20
+#define PIC_SLAVE 0xA0
+#define PIC_MASTER_DATA (PIC_MASTER + 1)
+#define PIC_SLAVE_DATA (PIC_SLAVE + 1)
+
+void disable_pics() {
+  // Write a fully set bitmask to both PICs, so no hardware interrupts
+  // come through.
+  // TODO(jasonpr): Move PIC-related code elsewhere.
+  outb(PIC_MASTER_DATA, 0xFF);
+  outb(PIC_SLAVE_DATA, 0xFF);
+}
+
 void setup_idt() {
   for (int entry = 0; entry < IDT_SIZE; entry++) {
     idt[entry] = idt_entry((uintptr_t) trap_functions[entry]);
@@ -89,6 +103,7 @@ void setup_idt() {
 }
 
 void interrupts_initialize() {
+  disable_pics();
   setup_idt();
   enable_interrupts();
 }

--- a/src/kernel/interrupts.c
+++ b/src/kernel/interrupts.c
@@ -2,6 +2,7 @@
 #include <x86.h>
 
 #include "interrupts.h"
+#include "cprintf.h"
 #include "panic.h"
 #include "segmentation.h"
 
@@ -22,8 +23,15 @@ struct InterruptDescriptor idt_entry(uintptr_t handler_pointer) {
   return result;
 }
 
-void handle_interrupt(int interrupt) {
-  switch (interrupt) {
+void print_trap_frame(struct TrapFrame *trap_frame) {
+  cprintf("Got trap %d from EIP 0x%08x.\n",
+	  trap_frame->interrupt_number, trap_frame->cpu_frame.eip);
+}
+
+void handle_interrupt(struct TrapFrame trap_frame) {
+  print_trap_frame(&trap_frame);
+
+  switch (trap_frame.interrupt_number) {
   case INTERRUPT_DIVIDE_ERROR:
     panic("Divide error.\n");
     break;
@@ -76,7 +84,7 @@ void handle_interrupt(int interrupt) {
     panic("Coprocessor error.\n");
     break;
   default:
-    panic("Unidentified interrupt: %d.\n", interrupt);
+    panic("Unidentified interrupt: %d.\n", trap_frame.interrupt_number);
     break;
   }
 }

--- a/src/kernel/interrupts.c
+++ b/src/kernel/interrupts.c
@@ -6,7 +6,6 @@
 #include "segmentation.h"
 
 static struct InterruptDescriptor idt[IDT_SIZE];
-
 static struct PseudoDescriptor idt_descriptor = {
   .limit = sizeof(struct InterruptDescriptor) * IDT_SIZE - 1,
   .base = (uintptr_t) &idt
@@ -24,8 +23,62 @@ struct InterruptDescriptor idt_entry(uintptr_t handler_pointer) {
 }
 
 void handle_interrupt(int interrupt) {
-  disable_interrupts();
-  panic("Got interrupt %d.\n", interrupt);
+  switch (interrupt) {
+  case INTERRUPT_DIVIDE_ERROR:
+    panic("Divide error.\n");
+    break;
+  case INTERRUPT_DEBUG_EXCEPTION:
+    panic("Debug error.\n");
+    break;
+  case INTERRUPT_NMI:
+    panic("Non-maskable interrupt.\n");
+    break;
+  case INTERRUPT_BREAKPOINT:
+    panic("Breakpoint.\n");
+    break;
+  case INTERRUPT_OVERFLOW:
+    panic("Overflow.\n");
+    break;
+  case INTERRUPT_BOUNDS_CHECK:
+    panic("Failed bounds check.\n");
+    break;
+  case INTERRUPT_INVALID_OPCODE:
+    panic("Invalid opcode.\n");
+    break;
+  case INTERRUPT_COPROCESSOR_NOT_AVAILABLE:
+    panic("Coprocessor not available.\n");
+    break;
+  case INTERRUPT_DOUBLE_FAULT:
+    panic("Double fault.\n");
+    break;
+  case INTERRUPT_RESERVED_9:
+    panic("Reserved interrupt (9).\n");
+    break;
+  case INTERRUPT_INVALID_TSS:
+    panic("Invalid TSS.\n");
+    break;
+  case INTERRUPT_SEGMENT_NOT_PRESENT:
+    panic("Segment not present.\n");
+    break;
+  case INTERRUPT_STACK_EXCEPTION:
+    panic("Stack exception.\n");
+    break;
+  case INTERRUPT_GENERAL_PROTECTION_FAULT:
+    panic("General protection fault.\n");
+    break;
+  case INTERRUPT_PAGE_FAULT:
+    panic("Page fault.\n");
+    break;
+  case INTERRUPT_RESERVED_15:
+    panic("Reserved interrupt (15).\n");
+    break;
+  case INTERRUPT_COPROCESSOR_ERROR:
+    panic("Coprocessor error.\n");
+    break;
+  default:
+    panic("Unidentified interrupt: %d.\n", interrupt);
+    break;
+  }
 }
 
 void setup_idt() {

--- a/src/kernel/interrupts.h
+++ b/src/kernel/interrupts.h
@@ -25,7 +25,9 @@
 #define INTERRUPT_PAGE_FAULT 14
 #define INTERRUPT_RESERVED_15 15
 #define INTERRUPT_COPROCESSOR_ERROR 16
-#define IDT_SIZE 17
+#define INTERRUPT_PASS_THROUGH 50
+#define INTERRUPT_SYSCALL 60
+#define IDT_SIZE 62
 
 // An InterruptDescriptor is a "Trap Gate" from page 157 of the i386
 // manual.  The author of

--- a/src/kernel/interrupts.h
+++ b/src/kernel/interrupts.h
@@ -1,0 +1,51 @@
+#ifndef ASBESTOS_KERNEL_INTERRUPTS_H_
+#define ASBESTOS_KERNEL_INTERRUPTS_H_
+
+#include <stdint.h>
+
+// Useful resources:
+// http://www.intel.com/design/pentium/manuals/24143004.pdf
+// https://css.csail.mit.edu/6.858/2010/readings/i386.pdf
+
+#define INTERRUPT_DIVIDE_ERROR 0
+#define INTERRUPT_DEBUG_EXCEPTION 1
+#define INTERRUPT_NMI 2
+#define INTERRUPT_BREAKPOINT 3
+#define INTERRUPT_OVERFLOW 4
+#define INTERRUPT_BOUNDS_CHECK 5
+#define INTERRUPT_INVALID_OPCODE 6
+#define INTERRUPT_COPROCESSOR_NOT_AVAILABLE 7
+#define INTERRUPT_DOUBLE_FAULT 8
+#define INTERRUPT_RESERVED_9 9
+#define INTERRUPT_INVALID_TSS 10
+#define INTERRUPT_SEGMENT_NOT_PRESENT 11
+#define INTERRUPT_STACK_EXCEPTION 12
+#define INTERRUPT_GENERAL_PROTECTION_FAULT 13
+#define INTERRUPT_PAGE_FAULT 14
+#define INTERRUPT_RESERVED_15 15
+#define INTERRUPT_COPROCESSOR_ERROR 16
+#define IDT_SIZE 17
+
+// An InterruptDescriptor is a "Trap Gate" from page 157 of the i386
+// manual.  The author of
+// http://littleosbook.github.io/#interrupts-handlers recommends using
+// this type of gate (not a task gate or an interrupt gate).
+struct InterruptDescriptor {
+  uint16_t offset_15_0;
+  struct SegmentSelector selector;
+  unsigned int unused_1 : 5;
+  unsigned int zeroes_1 : 3;
+  // The manual doesn't explain these flags.
+  // It only specifies that they must have values 0b01111.
+  unsigned int flags : 5;
+  unsigned int privilege_level : 2;
+  unsigned int present : 1;
+  uint16_t offset_31_16;
+} __attribute__((packed));
+
+void interrupts_initialize();
+void handle_interrupt();
+
+extern const uintptr_t trap_functions[];
+
+#endif  // ASBESTOS_KERNEL_INTERRUPTS_H_

--- a/src/kernel/interrupts.h
+++ b/src/kernel/interrupts.h
@@ -2,6 +2,7 @@
 #define ASBESTOS_KERNEL_INTERRUPTS_H_
 
 #include <stdint.h>
+#include <x86.h>
 
 // Useful resources:
 // http://www.intel.com/design/pentium/manuals/24143004.pdf
@@ -42,6 +43,21 @@ struct InterruptDescriptor {
   unsigned int present : 1;
   uint16_t offset_31_16;
 } __attribute__((packed));
+
+
+struct CpuExceptionFrame {
+  uint32_t error_code;
+  uintptr_t eip;
+  uint16_t cs;
+  uint16_t padding_1;
+  uint16_t eflags;
+};
+
+struct TrapFrame {
+  struct PushedRegisters pushed_registers;
+  uint32_t interrupt_number;
+  struct CpuExceptionFrame cpu_frame;
+};
 
 void interrupts_initialize();
 void handle_interrupt();

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -49,5 +49,7 @@ void kernel_main(struct PushedRegisters registers) {
   interrupts_initialize();
 
   cprintf("Survived startup.\n");
+
+  fire_interrupt(INTERRUPT_PASS_THROUGH);
   run_monitor();
 }

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -45,7 +45,9 @@ void kernel_main(struct PushedRegisters registers) {
   kernel_validate_multiboot_handoff(registers.eax, multiboot_info);
   memory_catalog_initialize(multiboot_info);
 
+  cprintf("Initializing interrupt handling system.\n");
   interrupts_initialize();
 
+  cprintf("Survived startup.\n");
   run_monitor();
 }

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -2,6 +2,7 @@
 #include "cprintf.h"
 #include "link_address.h"
 #include "memory_catalog.h"
+#include "interrupts.h"
 #include "monitor.h"
 #include "multiboot.h"
 #include "panic.h"
@@ -43,6 +44,8 @@ void kernel_main(struct PushedRegisters registers) {
   struct MultibootInfo *multiboot_info = (struct MultibootInfo *) registers.ebx;
   kernel_validate_multiboot_handoff(registers.eax, multiboot_info);
   memory_catalog_initialize(multiboot_info);
+
+  interrupts_initialize();
 
   run_monitor();
 }

--- a/src/kernel/segmentation.c
+++ b/src/kernel/segmentation.c
@@ -39,7 +39,7 @@ void initialize_gdt() {
   // Add a data segment.
   gdt[GDT_DATA_SEGMENT_OFFSET] = spanning_gdt_entry(true, false);
 
-  uintptr_t lgdt_target = pseudo_descriptor_gdt_address(&gdt_descriptor);
+  uintptr_t lgdt_target = pseudo_descriptor_address(&gdt_descriptor);
   load_gdt(lgdt_target);
 }
 

--- a/src/kernel/segmentation.c
+++ b/src/kernel/segmentation.c
@@ -39,8 +39,7 @@ void initialize_gdt() {
   // Add a data segment.
   gdt[GDT_DATA_SEGMENT_OFFSET] = spanning_gdt_entry(true, false);
 
-  uintptr_t lgdt_target = pseudo_descriptor_address(&gdt_descriptor);
-  load_gdt(lgdt_target);
+  load_gdt(&gdt_descriptor);
 }
 
 void initialize_selectors() {

--- a/src/kernel/segmentation.c
+++ b/src/kernel/segmentation.c
@@ -43,30 +43,18 @@ void initialize_gdt() {
 }
 
 void initialize_selectors() {
-  struct SegmentSelector null_selector = {
-    .index = GDT_NULL_SEGMENT_OFFSET
-  };
-
-  struct SegmentSelector code_selector = {
-    .index = GDT_CODE_SEGMENT_OFFSET
-  };
-
-  struct SegmentSelector data_selector = {
-    .index = GDT_DATA_SEGMENT_OFFSET
-  };
-
-  load_cs(code_selector);
+  load_cs(GDT_CODE_SELECTOR);
 
   // Load DS for normal data access, SS for stack access, and ES for
   // string-related data access.
-  load_ds(data_selector);
-  load_ss(data_selector);
-  load_es(data_selector);
+  load_ds(GDT_DATA_SELECTOR);
+  load_ss(GDT_DATA_SELECTOR);
+  load_es(GDT_DATA_SELECTOR);
 
   // We don't use the general-purpose segments.  Make sure we segfault
   // if we accidentally use them.
-  load_fs(null_selector);
-  load_gs(null_selector);
+  load_fs(GDT_NULL_SELECTOR);
+  load_gs(GDT_NULL_SELECTOR);
 }
 
 void segmentation_initialize() {

--- a/src/kernel/segmentation.h
+++ b/src/kernel/segmentation.h
@@ -45,6 +45,19 @@ struct SegmentDescriptor {
 #define GDT_DATA_SEGMENT_OFFSET 2
 #define GDT_SIZE 3
 
+static struct SegmentSelector GDT_NULL_SELECTOR = {
+  .index = GDT_NULL_SEGMENT_OFFSET
+};
+
+static struct SegmentSelector GDT_CODE_SELECTOR = {
+  .index = GDT_CODE_SEGMENT_OFFSET
+};
+
+static struct SegmentSelector GDT_DATA_SELECTOR = {
+  .index = GDT_DATA_SEGMENT_OFFSET
+};
+
+
 void segmentation_initialize();
 
 #endif  // ASBESTOS_KERNEL_SEGMENT_H_

--- a/src/lib/segments.c
+++ b/src/lib/segments.c
@@ -1,7 +1,7 @@
 #include <segments.h>
 #include <stdint.h>
 
-uintptr_t pseudo_descriptor_gdt_address(struct PseudoDescriptor *pd) {
+uintptr_t pseudo_descriptor_address(struct PseudoDescriptor *pd) {
   // The first two bytes are padding.
   return ((uintptr_t) pd) + 2;
 }

--- a/src/lib/segments.h
+++ b/src/lib/segments.h
@@ -20,6 +20,6 @@ struct PseudoDescriptor {
   uintptr_t base;
 } __attribute__((aligned(4), packed));
 
-uintptr_t pseudo_descriptor_gdt_address(struct PseudoDescriptor *pd);
+uintptr_t pseudo_descriptor_address(struct PseudoDescriptor *pd);
 
 #endif  // ASBESTOS_LIB_SEGMENTS_H_

--- a/src/lib/x86.h
+++ b/src/lib/x86.h
@@ -21,6 +21,8 @@ static __inline void load_gs(struct SegmentSelector selector) __attribute__((alw
 static __inline void load_ss(struct SegmentSelector selector) __attribute__((always_inline));
 static __inline void load_gdt(struct PseudoDescriptor *gdt) __attribute__((always_inline));
 static __inline void load_idt(struct PseudoDescriptor *idt) __attribute__((always_inline));
+static __inline void enable_interrupts() __attribute__((always_inline));
+static __inline void disable_interrupts() __attribute__((always_inline));
 
 
 // Get the current base pointer.
@@ -106,6 +108,18 @@ static void load_idt(struct PseudoDescriptor *idt) {
   __asm __volatile("lidt (%0)" :
 		   /* No output. */ :
 		   "r" (pseudo_descriptor_address(idt)));
+}
+
+static void enable_interrupts() {
+  __asm __volatile("sti" :
+		   /* No output. */ :
+		   /* No input. */);
+}
+
+static void disable_interrupts() {
+  __asm __volatile("cli" :
+		   /* No output. */ :
+		   /* No input. */);
 }
 
 struct PushedRegisters {

--- a/src/lib/x86.h
+++ b/src/lib/x86.h
@@ -20,6 +20,7 @@ static __inline void load_fs(struct SegmentSelector selector) __attribute__((alw
 static __inline void load_gs(struct SegmentSelector selector) __attribute__((always_inline));
 static __inline void load_ss(struct SegmentSelector selector) __attribute__((always_inline));
 static __inline void load_gdt(struct PseudoDescriptor *gdt) __attribute__((always_inline));
+static __inline void load_idt(struct PseudoDescriptor *idt) __attribute__((always_inline));
 
 
 // Get the current base pointer.
@@ -99,6 +100,12 @@ static void load_gdt(struct PseudoDescriptor *gdt) {
   __asm __volatile("lgdt (%0)" :
 		   /* No output. */ :
 		   "r" (pseudo_descriptor_address(gdt)));
+}
+
+static void load_idt(struct PseudoDescriptor *idt) {
+  __asm __volatile("lidt (%0)" :
+		   /* No output. */ :
+		   "r" (pseudo_descriptor_address(idt)));
 }
 
 struct PushedRegisters {

--- a/src/lib/x86.h
+++ b/src/lib/x86.h
@@ -23,6 +23,7 @@ static __inline void load_gdt(struct PseudoDescriptor *gdt) __attribute__((alway
 static __inline void load_idt(struct PseudoDescriptor *idt) __attribute__((always_inline));
 static __inline void enable_interrupts() __attribute__((always_inline));
 static __inline void disable_interrupts() __attribute__((always_inline));
+static __inline void fire_interrupt(uint8_t interrupt_number) __attribute__((always_inline));
 
 
 // Get the current base pointer.
@@ -121,6 +122,13 @@ static void disable_interrupts() {
 		   /* No output. */ :
 		   /* No input. */);
 }
+
+static void fire_interrupt(uint8_t interrupt_number) {
+  __asm __volatile("int %0" :
+		   /* No output. */ :
+		   "i" (interrupt_number));
+}
+
 
 struct PushedRegisters {
   uint32_t edi;

--- a/src/lib/x86.h
+++ b/src/lib/x86.h
@@ -19,7 +19,7 @@ static __inline void load_es(struct SegmentSelector selector) __attribute__((alw
 static __inline void load_fs(struct SegmentSelector selector) __attribute__((always_inline));
 static __inline void load_gs(struct SegmentSelector selector) __attribute__((always_inline));
 static __inline void load_ss(struct SegmentSelector selector) __attribute__((always_inline));
-static __inline void load_gdt(uintptr_t start) __attribute__((always_inline));
+static __inline void load_gdt(struct PseudoDescriptor *gdt) __attribute__((always_inline));
 
 
 // Get the current base pointer.
@@ -95,10 +95,10 @@ static void load_ss(struct SegmentSelector selector) {
 		   "r" (selector));
 }
 
-static void load_gdt(uintptr_t start) {
+static void load_gdt(struct PseudoDescriptor *gdt) {
   __asm __volatile("lgdt (%0)" :
 		   /* No output. */ :
-		   "r" (start));
+		   "r" (pseudo_descriptor_address(gdt)));
 }
 
 struct PushedRegisters {


### PR DESCRIPTION
For now, almost all interrupts result in a panic that prints the type of interrupt that has been caught.  However, the "pass-through" interrupt has been implemented, which does nothing and returns control flow to the caller via an `iret`.

In particular, we:
  * Allow the setup and loading of an IDT (Interrupt Descriptor Table).
  * Factor out pseudo-descriptor machinery which is common to GDT and IDT functionality.
  * Implement an interrupt dispatcher.
  * Implement the pass-through interrupt, which does nothing (for testing)!