### PR TITLE
Unify keyboard and serial input

### DIFF
--- a/src/kernel/input.c
+++ b/src/kernel/input.c
@@ -2,8 +2,6 @@
 #include <ringbuffer.h>
 #include "cprintf.h"
 #include "input.h"
-#include "keyboard.h"
-#include "serial.h"
 #include "panic.h"
 
 #define CHARACTER_RING_SIZE 100
@@ -31,14 +29,6 @@ int read_all_input(int (*input_read)(char *output)) {
     }
   }
   return ERR_INPUT_BUFFER_FULL;
-}
-
-int get_keyboard_input() {
-  return read_all_input(keyboard_read);
-}
-
-int get_serial_input() {
-  return read_all_input(serial_read);
 }
 
 char input_character() {

--- a/src/kernel/input.c
+++ b/src/kernel/input.c
@@ -1,10 +1,61 @@
 #include <read.h>
+#include <ringbuffer.h>
 #include "cprintf.h"
 #include "input.h"
 #include "keyboard.h"
 
+#define CHARACTER_RING_SIZE 100
+
+static char character_ring_space[CHARACTER_RING_SIZE];
+static struct RingBuffer character_buffer = {
+  character_ring_space,
+  CHARACTER_RING_SIZE,
+  0,
+  0
+};
+
+
+int get_keyboard_input() {
+  while (keyboard_has_output()) {
+    if (ring_buffer_full(&character_buffer)) {
+      return -1;
+    }
+    char ascii_char = keyboard_consume_keypress();
+    if (ascii_char) {
+      ring_buffer_append(&character_buffer, ascii_char);
+    }
+  }
+  return 0;
+}
+
+int get_serial_input() {
+  while (serial_can_read()) {
+    if (ring_buffer_full(&character_buffer)) {
+      return -1;
+    }
+    // Note that 0x00 is not a special value, as it was for the
+    // keyboard.  If it comes over the serial line, we append it onto
+    // the buffer.
+    ring_buffer_append(&character_buffer, serial_read());
+  }
+  return 0;
+}
+
 char input_character() {
-  char input = keyboard_read();
+  while (ring_buffer_empty(&character_buffer)) {
+    // Spin until an interrupt handler feeds the buffer.
+  }
+  char input = ring_buffer_pop(&character_buffer);
+
+  // TODO(jasonpr): Decide on a good time to do newline conversions.
+  // This will involve determining which functions should return the
+  // raw data they get from the hardware, and which ones should expose
+  // a consistent interface.
+  // Since we use '\n' as a full line ending in vga.c, this
+  // conversion works.  But, it's hacky.
+  if (input == '\r') {
+    input = '\n';
+  }
   cprint_char(input);
   return input;
 }

--- a/src/kernel/input.c
+++ b/src/kernel/input.c
@@ -34,16 +34,20 @@ int get_keyboard_input() {
 }
 
 int get_serial_input() {
-  while (serial_can_read()) {
-    if (ring_buffer_full(&character_buffer)) {
-      return -1;
+  while (!ring_buffer_full(&character_buffer)) {
+    char input;
+    int result = serial_read(&input);
+    if (result ==0) {
+      ring_buffer_append(&character_buffer, input);
+    } else if (result == INPUT_RETRY) {
+      continue;
+    } else if (result == INPUT_EXHAUSTED) {
+      return 0;
+    } else {
+      panic("[INPUT] Unexpected serial result: 0x%02x\n", result);
     }
-    // Note that 0x00 is not a special value, as it was for the
-    // keyboard.  If it comes over the serial line, we append it onto
-    // the buffer.
-    ring_buffer_append(&character_buffer, serial_read());
   }
-  return 0;
+  return ERR_INPUT_BUFFER_FULL;
 }
 
 char input_character() {

--- a/src/kernel/input.h
+++ b/src/kernel/input.h
@@ -3,6 +3,19 @@
 
 #include <stddef.h>
 
+#define ERR_INPUT_BUFFER_FULL -1
+
+// Return values for `$INPUT_read()` functions:
+
+// The call to a input read function failed because there is no more
+// input to consume at the moment.
+#define INPUT_EXHAUSTED -1
+// The call to an input read function did not produce any data.  There
+// still may be more input to consume.  (For example, the function
+// might have read a key-up event, which produces no character data.)
+#define INPUT_RETRY -2
+
+
 int get_keyboard_input();
 int get_serial_input();
 char input_character();

--- a/src/kernel/input.h
+++ b/src/kernel/input.h
@@ -3,6 +3,8 @@
 
 #include <stddef.h>
 
+int get_keyboard_input();
+int get_serial_input();
 char input_character();
 char * input_string(char *buffer, size_t buffer_size);
 

--- a/src/kernel/input.h
+++ b/src/kernel/input.h
@@ -16,8 +16,7 @@
 #define INPUT_RETRY -2
 
 
-int get_keyboard_input();
-int get_serial_input();
+int read_all_input(int (*input_read)(char *output));
 char input_character();
 char * input_string(char *buffer, size_t buffer_size);
 

--- a/src/kernel/interrupts.c
+++ b/src/kernel/interrupts.c
@@ -4,6 +4,7 @@
 #include "interrupts.h"
 #include "cprintf.h"
 #include "input.h"
+#include "keyboard.h"
 #include "panic.h"
 #include "pic.h"
 #include "segmentation.h"
@@ -89,11 +90,11 @@ void handle_interrupt(struct TrapFrame trap_frame) {
     pic_send_eoi();
     break;
   case INTERRUPT_KEYBOARD:
-    get_keyboard_input();
+    read_all_input(keyboard_read);
     pic_send_eoi();
     break;
   case INTERRUPT_COM1:
-    get_serial_input();
+    read_all_input(serial_read);
     pic_send_eoi();
     break;
   case INTERRUPT_PASS_THROUGH:

--- a/src/kernel/interrupts.c
+++ b/src/kernel/interrupts.c
@@ -3,6 +3,7 @@
 
 #include "interrupts.h"
 #include "cprintf.h"
+#include "input.h"
 #include "panic.h"
 #include "pic.h"
 #include "segmentation.h"
@@ -88,13 +89,11 @@ void handle_interrupt(struct TrapFrame trap_frame) {
     pic_send_eoi();
     break;
   case INTERRUPT_KEYBOARD:
-    // TODO(jasonpr): Handle keyboard interrupt.
+    get_keyboard_input();
     pic_send_eoi();
     break;
   case INTERRUPT_COM1:
-    // TODO(jasonpr): Handle serial interrupt properly.
-    // The character should actually be put into an input buffer.
-    cprint_char(serial_read());
+    get_serial_input();
     pic_send_eoi();
     break;
   case INTERRUPT_PASS_THROUGH:

--- a/src/kernel/keyboard.c
+++ b/src/kernel/keyboard.c
@@ -83,12 +83,6 @@ void keyboard_write_command(char command) {
   outb(KEYBOARD_COMMAND_IO_PORT, command);
 }
 
-bool keyboard_has_output() {
-  // Returns whether the keyboard has data to be read.
-  // That is, returns true if the output buffer is not empty.
-  return inb(KEYBOARD_STATUS_IO_PORT) & KEYBOARD_OUTPUT_BUFFER_FULL;
-}
-
 char keyboard_read_data() {
   spin_until_output_buffer_full();
   return inb(KEYBOARD_DATA_IO_PORT);
@@ -116,7 +110,7 @@ void keyboard_initialize() {
 }
 
 int keyboard_read(char *output) {
-  if (!keyboard_has_output()) {
+  if (!(inb(KEYBOARD_STATUS_IO_PORT) & KEYBOARD_OUTPUT_BUFFER_FULL)) {
     return INPUT_EXHAUSTED;
   }
 

--- a/src/kernel/keyboard.c
+++ b/src/kernel/keyboard.c
@@ -6,8 +6,8 @@
 //  * The IBM PC AT Technical Reference (1502494), available online at
 //    ia801607.us.archive.org/30/items/bitsavers_ibmpcat150ferenceMar84_26847525/1502494_PC_AT_Technical_Reference_Mar84.pdf
 
-#include <ringbuffer.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <x86.h>
 #include "cprintf.h"
 #include "panic.h"
@@ -27,13 +27,10 @@
 #define KEYBOARD_INTERFACE_TEST_COMMAND 0xAB
 #define KEYBOARD_INTERFACE_TEST_EXPECTED_RESULT 0x00
 
-#define CHARACTER_RING_SIZE 100
-
 static const char kScancodeLeftShiftPressed = 0x2A;
 static const char kScancodeLeftShiftReleased = 0xAA;
 static const char kScancodeRightShiftPressed = 0x36;
 static const char kScancodeRightShiftReleased = 0xB6;
-
 
 static char key_to_ascii[256] =
 {
@@ -66,13 +63,6 @@ static char key_to_ascii_shift[256] =
 };
 
 // Keyboard state.
-static char character_ring_space[CHARACTER_RING_SIZE];
-static struct RingBuffer character_buffer = {
-  character_ring_space,
-  CHARACTER_RING_SIZE,
-  0,
-  0
-};
 static bool left_shift_pressed = false; 
 static bool right_shift_pressed = false; 
 
@@ -91,6 +81,12 @@ void spin_until_output_buffer_full() {
 void keyboard_write_command(char command) {
   spin_until_input_buffer_empty();
   outb(KEYBOARD_COMMAND_IO_PORT, command);
+}
+
+bool keyboard_has_output() {
+  // Returns whether the keyboard has data to be read.
+  // That is, returns true if the output buffer is not empty.
+  return inb(KEYBOARD_STATUS_IO_PORT) & KEYBOARD_OUTPUT_BUFFER_FULL;
 }
 
 char keyboard_read_data() {
@@ -119,14 +115,7 @@ void keyboard_initialize() {
   keyboard_interface_test();
 }
 
-// Return zero if the keypress was successfully consumed, -1 otherwise.
-// A failure will occur if the kernel's key buffer is full.
-int consume_keypress() {
-  if (ring_buffer_full(&character_buffer)) {
-    // Fail immediately, even though it's possible that the key will
-    // not require adding to the buffer.
-    return -1;
-  }
+char keyboard_consume_keypress() {
   char scancode = keyboard_read_data();
   if (scancode == kScancodeLeftShiftPressed) {
     left_shift_pressed = true;
@@ -141,17 +130,7 @@ int consume_keypress() {
   char ascii_character = (left_shift_pressed || right_shift_pressed)
       ? key_to_ascii_shift[scancode_index]
       : key_to_ascii[scancode_index];
-  if (ascii_character) {
-    ring_buffer_append(&character_buffer, ascii_character);
-  }
-  // Otherwise, there was no ASCII value for this key.  It must have
-  // been special.  For now, ignore it.
-  return 0;
-}
-
-char keyboard_read() {
-  while (ring_buffer_empty(&character_buffer)) {
-    consume_keypress();
-  }
-  return ring_buffer_pop(&character_buffer);
+  // Return the ASCII character, or 0x00 if there is no matching
+  // typeable character.
+  return ascii_character;
 }

--- a/src/kernel/keyboard.h
+++ b/src/kernel/keyboard.h
@@ -1,7 +1,11 @@
 #ifndef ASBESTOS_KERNEL_KEYBOARD_H_
 #define ASBESTOS_KERNEL_KEYBOARD_H_
 
+#include <stdbool.h>
+
 void keyboard_initialize();
 char keyboard_read();
+bool keyboard_has_output();
+char keyboard_consume_keypress();
 
 #endif  // ASBESTOS_KERNEL_KEYBOARD_H_

--- a/src/kernel/keyboard.h
+++ b/src/kernel/keyboard.h
@@ -1,11 +1,8 @@
 #ifndef ASBESTOS_KERNEL_KEYBOARD_H_
 #define ASBESTOS_KERNEL_KEYBOARD_H_
 
-#include <stdbool.h>
-
 void keyboard_initialize();
-char keyboard_read();
-bool keyboard_has_output();
+int keyboard_read(char *output);
 char keyboard_consume_keypress();
 
 #endif  // ASBESTOS_KERNEL_KEYBOARD_H_

--- a/src/kernel/keyboard.h
+++ b/src/kernel/keyboard.h
@@ -3,6 +3,5 @@
 
 void keyboard_initialize();
 int keyboard_read(char *output);
-char keyboard_consume_keypress();
 
 #endif  // ASBESTOS_KERNEL_KEYBOARD_H_

--- a/src/kernel/serial.c
+++ b/src/kernel/serial.c
@@ -10,6 +10,7 @@
 
 #include <stdbool.h>
 #include <x86.h>
+#include "input.h"
 #include "serial.h"
 
 #define COM1_IO_PORT 0x3f8
@@ -82,11 +83,12 @@ bool serial_can_read() {
     UART_LINE_STATUS_DATA_READY;
 }
 
-char serial_read() {
-  while (!serial_can_read()){
-    // Spin around.
+int serial_read(char *output) {
+  if (!serial_can_read()) {
+    return INPUT_EXHAUSTED;
   }
-  return inb(UART_DATA_IO_PORT);
+  *output = inb(UART_DATA_IO_PORT);
+  return 0;
 }
 
 void serial_initialize() {

--- a/src/kernel/serial.h
+++ b/src/kernel/serial.h
@@ -1,8 +1,11 @@
 #ifndef SERIAL_H_
 #define SERIAL_H_
 
+#include <stdbool.h>
+
 void serial_initialize();
 void serial_write(char character);
 char serial_read();
+bool serial_can_read();
 
 #endif  // SERIAL_H_

--- a/src/kernel/serial.h
+++ b/src/kernel/serial.h
@@ -1,11 +1,8 @@
 #ifndef SERIAL_H_
 #define SERIAL_H_
 
-#include <stdbool.h>
-
 void serial_initialize();
 void serial_write(char character);
-char serial_read();
-bool serial_can_read();
+int serial_read(char *output);
 
 #endif  // SERIAL_H_

--- a/src/lib/read.c
+++ b/src/lib/read.c
@@ -5,7 +5,8 @@ char * read_string(char (*read_character)(), char *buffer, size_t buffer_size){
   while (index < buffer_size - 1) {
     char input = read_character();
     buffer[index++] = input;
-    if (input == '\n') {
+    // TODO(jasonpr): Allow \r\n to be read as a single "enter".
+    if (input == '\n' || input == '\r') {
       break;
     }
   }


### PR DESCRIPTION
There is now a single input buffer, fed by both keyboard and serial-received data.

The input buffer is filled by interrupt handlers.  (This means the original polling-based input system has been fully converted to the interrupt-based system.)

For now, there is no way for clients of the input system to distinguish between keyboard input and serial input.  So, we can issue commands to Abestos via the serial port.  And, since our QEMU setup maps STDIN to COM1-in, we can control Asbestos from the terminal of the host OS that QEMU is running on.